### PR TITLE
Update eval.py (Environment reloading, Saving video)

### DIFF
--- a/scripts_paper/eval.py
+++ b/scripts_paper/eval.py
@@ -14,7 +14,6 @@ from omni_drones.learning import (
     TDMPCPolicy,
 )
 
-# modify - 1
 class Every:
     def __init__(self, func, steps):
         self.func = func
@@ -26,7 +25,6 @@ class Every:
             self.func(*args, **kwargs)
         self.i += 1
 import imageio
-# modify - 1
 
 algos = {
     "mappo": MAPPOPolicy,
@@ -61,7 +59,6 @@ def main(cfg):
     if formation_checkpoint is not None:
         formation_policy.load_state_dict(torch.load(formation_checkpoint))
 
-# modify - 2
     def record_frame(frames, *args, **kwargs):
             frame = env.render(mode="rgb_array")
             frames.append(frame)
@@ -114,7 +111,6 @@ def main(cfg):
         print("completed the total video")
 
     print("done everything")
-# modify - 2
 
 if __name__ == "__main__":
     main()

--- a/scripts_paper/eval.py
+++ b/scripts_paper/eval.py
@@ -14,16 +14,6 @@ from omni_drones.learning import (
     TDMPCPolicy,
 )
 
-class Every:
-    def __init__(self, func, steps):
-        self.func = func
-        self.steps = steps
-        self.i = 0
-
-    def __call__(self, *args, **kwargs):
-        if self.i % self.steps == 0:
-            self.func(*args, **kwargs)
-        self.i += 1
 import imageio
 
 algos = {
@@ -60,25 +50,19 @@ def main(cfg):
         formation_policy.load_state_dict(torch.load(formation_checkpoint))
 
     def record_frame(frames, *args, **kwargs):
-            frame = env.render(mode="rgb_array")
-            frames.append(frame)
+        frame = env.render(mode="rgb_array")
+        frames.append(frame)
 
-    frames_transport = []
-    frames_formation = []
+    frames = []
     seed = 1
 
     env.enable_render(True)
-    env.eval()
     env.set_seed(seed)
     state = env.reset()
 
-    print("start formation")
-
     while not state['done']:
         state = env.step(formation_policy(state, deterministic=True))['next']
-        record_frame(frames_formation)
-
-    print("finish formation")
+        record_frame(frames)
 
     with torch.no_grad():
         state_snapshot = env.snapshot_state()
@@ -89,28 +73,13 @@ def main(cfg):
     env = env_class(cfg, headless=cfg.headless, initial_state=state_snapshot)  
     state = env.reset()
 
-    print("start transport")
-
     while not state['done']:
         state = env.step(transport_policy(state, deterministic=True))['next']
-        record_frame(frames_transport)
+        record_frame(frames)
 
-    print("finish transport")
-
-    if len(frames_formation):
-        imageio.mimsave("result_video/formation_video.mp4", frames_formation, fps=0.5 / cfg.sim.dt)
-        print("completed the formation video")
-    if len(frames_transport):
-        imageio.mimsave("result_video/transport_video.mp4", frames_transport, fps=0.5 / cfg.sim.dt)
-        print("completed the transport video")
-    
-    frames_total = frames_formation + frames_formation
-
-    if len(frames_total):
-        imageio.mimsave("result_video/total_video.mp4", frames_total, fps=0.5 / cfg.sim.dt)
-        print("completed the total video")
-
-    print("done everything")
+    if len(frames):
+        imageio.mimsave("result_video/video.mp4", frames, fps=0.5 / cfg.sim.dt)
+        print("completed the video")
 
 if __name__ == "__main__":
     main()

--- a/scripts_paper/eval.py
+++ b/scripts_paper/eval.py
@@ -14,6 +14,20 @@ from omni_drones.learning import (
     TDMPCPolicy,
 )
 
+# modify - 1
+class Every:
+    def __init__(self, func, steps):
+        self.func = func
+        self.steps = steps
+        self.i = 0
+
+    def __call__(self, *args, **kwargs):
+        if self.i % self.steps == 0:
+            self.func(*args, **kwargs)
+        self.i += 1
+import imageio
+# modify - 1
+
 algos = {
     "mappo": MAPPOPolicy,
     "happo": HAPPOPolicy,
@@ -47,17 +61,60 @@ def main(cfg):
     if formation_checkpoint is not None:
         formation_policy.load_state_dict(torch.load(formation_checkpoint))
 
+# modify - 2
+    def record_frame(frames, *args, **kwargs):
+            frame = env.render(mode="rgb_array")
+            frames.append(frame)
+
+    frames_transport = []
+    frames_formation = []
+    seed = 1
+
+    env.enable_render(True)
+    env.eval()
+    env.set_seed(seed)
     state = env.reset()
-    while True:
-        while not state['done']:
-            state = env.step(transport_policy(state, deterministic=True))['next']
 
+    print("start formation")
+
+    while not state['done']:
+        state = env.step(formation_policy(state, deterministic=True))['next']
+        record_frame(frames_formation)
+
+    print("finish formation")
+
+    with torch.no_grad():
         state_snapshot = env.snapshot_state()
-        simulation_app.context.close_stage()
-        simulation_app.context.new_stage()
-        env = env_class(cfg, headless=cfg.headless, initial_state=state_snapshot)
-        state = env.reset()
 
+    simulation_app.context.close_stage()
+    simulation_app.context.new_stage()
+
+    env = env_class(cfg, headless=cfg.headless, initial_state=state_snapshot)  
+    state = env.reset()
+
+    print("start transport")
+
+    while not state['done']:
+        state = env.step(transport_policy(state, deterministic=True))['next']
+        record_frame(frames_transport)
+
+    print("finish transport")
+
+    if len(frames_formation):
+        imageio.mimsave("result_video/formation_video.mp4", frames_formation, fps=0.5 / cfg.sim.dt)
+        print("completed the formation video")
+    if len(frames_transport):
+        imageio.mimsave("result_video/transport_video.mp4", frames_transport, fps=0.5 / cfg.sim.dt)
+        print("completed the transport video")
+    
+    frames_total = frames_formation + frames_formation
+
+    if len(frames_total):
+        imageio.mimsave("result_video/total_video.mp4", frames_total, fps=0.5 / cfg.sim.dt)
+        print("completed the total video")
+
+    print("done everything")
+# modify - 2
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
eval.py 내 환경 재로딩 및 비디오 저장 코드 추가합니다.

formation 과정이 종료되면, 그때의 state_snapshot을 저장하여, transport 용 환경을 재로딩하게 구현되어 있습니다.

비디오는 formation 과정, transport 과정, 전체 과정 총 3개의 video가 저장되게 구현했습니다. 

transporting일 때, logistics.py 내 _compute_state_and_obs 함수가 미구현 상태인데, 
구현이 완료된다면 재로딩 된 환경에서 올바른 state를 출력할 수 있습니다. 